### PR TITLE
fix(tsconfig): ignoreDeprecations と baseUrl を削除し paths を相対パスに更新

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,13 +22,11 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "baseUrl": ".",
-    "ignoreDeprecations": "6.0",
     "rootDir": "./src",
     "types": ["jest", "node"],
     "newLine": "LF",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
## 概要

TypeScript v6.0 アップグレード時の暫定対応として追加した設定を削除し、根本的な修正を行います。

## 変更内容

- `baseUrl: "."` を削除
- `paths` を相対パス `"./src/*"` に更新（`baseUrl` 削除に伴う対応）
- `ignoreDeprecations: "6.0"` を削除（TypeScript 7.0 では無効化されるため）

## 確認事項

- `tsc --noEmit` による型チェックが通ること確認済み
- `pnpm lint` による Lint チェックが通ること確認済み

Fixes #2257