### PR TITLE
fix: resolve eslint-config 1.15.44 (unicorn rules) lint errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ pnpm generate-schema  # schema/Configuration.json を再生成
 - `src/main.ts`: エントリーポイント。取得・判定・通知の全体フロー制御。
 - `src/quicpay-campaigns.ts`: キャンペーン情報のスクレイピングとパース。サイト構造変更時はここを更新する。
 - `src/discord.ts`: Discord 通知 (Embed 送信)。
-- `src/config.ts`: 設定の読み込みと型定義 (`Configuration`)、パス定義。
+- `src/config.ts`: 設定の読み込みと型定義 (`Config`)、パス定義。
 - `src/notified.ts`: 通知済み情報の永続化 (`Notified` クラス)。
 
 ## コーディング規約
@@ -38,7 +38,7 @@ pnpm generate-schema  # schema/Configuration.json を再生成
 
 ## リポジトリ固有
 - スクレイピング対象: `https://www.quicpay.jp/campaign/`。対象サイトの規約と負荷に配慮する。
-- 通知先: Discord Webhook もしくは Bot (token + channel_id)。設定は `src/config.ts` の `Configuration` 参照。
+- 通知先: Discord Webhook もしくは Bot (token + channel_id)。設定は `src/config.ts` の `Config` 参照。
 - 設定ファイル: `data/config.json` (環境変数 `CONFIG_PATH` で変更可)。スキーマは `schema/Configuration.json`。
 - 通知済み管理: `data/notified.json` (環境変数 `NOTIFIED_PATH` で変更可)。
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "type": "git"
   },
   "scripts": {
-    "generate-schema": "typescript-json-schema --required tsconfig.json Configuration -o schema/Configuration.json",
+    "generate-schema": "typescript-json-schema --required tsconfig.json Config -o schema/Configuration.json",
     "test": "jest",
     "lint:prettier": "prettier --check src",
     "lint:tsc": "tsc",

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@ export const PATH = {
   notified: process.env.NOTIFIED_PATH ?? 'data/notified.json',
 }
 
-export interface Configuration {
+export interface Config {
   /** Discord webhook URL or bot token */
   discord: {
     /** Discord webhook URL (required if using webhook) */
@@ -17,7 +17,7 @@ export interface Configuration {
   }
 }
 
-const isConfig = (config: any): config is Configuration => {
+const isConfig = (config: any): config is Config => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return (
     config &&
@@ -46,7 +46,7 @@ const isConfig = (config: any): config is Configuration => {
   )
 }
 
-export function loadConfig(): Configuration {
+export function loadConfig(): Config {
   if (!fs.existsSync(PATH.config)) {
     throw new Error('Config file not found')
   }

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -1,4 +1,4 @@
-import { Configuration } from './config'
+import { Config } from './config'
 
 export interface DiscordEmbedFooter {
   text: string
@@ -61,7 +61,7 @@ export interface DiscordEmbed {
   fields?: DiscordEmbedField[]
 }
 
-async function activateCrosspost(config: Configuration, messageId: string) {
+async function activateCrosspost(config: Config, messageId: string) {
   if (!config.discord.token || !config.discord.channel_id) {
     return
   }
@@ -83,7 +83,7 @@ async function activateCrosspost(config: Configuration, messageId: string) {
 }
 
 export async function sendDiscordMessage(
-  config: Configuration,
+  config: Config,
   text: string,
   embed?: DiscordEmbed,
   isCrosspost = false
@@ -91,7 +91,7 @@ export async function sendDiscordMessage(
   // webhook or bot
   if (config.discord.webhook_url) {
     // webhook
-    const res = await fetch(config.discord.webhook_url, {
+    const response = await fetch(config.discord.webhook_url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -101,15 +101,15 @@ export async function sendDiscordMessage(
         embeds: embed ? [embed] : undefined,
       }),
     })
-    if (res.status !== 204) {
-      throw new Error(`Discord webhook failed (${res.status})`)
+    if (response.status !== 204) {
+      throw new Error(`Discord webhook failed (${response.status})`)
     }
     return
   }
   if (config.discord.token && config.discord.channel_id) {
     // bot
 
-    const res = await fetch(
+    const response = await fetch(
       `https://discord.com/api/channels/${config.discord.channel_id}/messages`,
       {
         method: 'POST',
@@ -123,10 +123,10 @@ export async function sendDiscordMessage(
         }),
       }
     )
-    if (!res.ok) {
-      throw new Error(`Discord bot failed (${res.status})`)
+    if (!response.ok) {
+      throw new Error(`Discord bot failed (${response.status})`)
     }
-    const data = (await res.json()) as { id: string }
+    const data = (await response.json()) as { id: string }
     if (isCrosspost) {
       await activateCrosspost(config, data.id)
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,9 +45,11 @@ async function main() {
 
 ;(async () => {
   const logger = Logger.configure('main')
-  await main().catch((error: unknown) => {
+  try {
+    await main()
+  } catch (error: unknown) {
     logger.error('❌ Error occurred:', error as Error)
     // eslint-disable-next-line unicorn/no-process-exit
     process.exit(1)
-  })
+  }
 })()

--- a/src/quicpay-campaigns.ts
+++ b/src/quicpay-campaigns.ts
@@ -8,7 +8,7 @@ interface QuicpayCampaign {
   description: string
 }
 
-function checkAllNotUndefined(
+function isAllDefined(
   results: Partial<QuicpayCampaign>[]
 ): results is QuicpayCampaign[] {
   return results.every((result) => {
@@ -23,9 +23,9 @@ function checkAllNotUndefined(
 }
 
 export async function getCampaigns(): Promise<QuicpayCampaign[]> {
-  const res = await fetch('https://www.quicpay.jp/campaign/')
-  if (!res.ok) throw new Error(`HTTP error: ${res.status}`)
-  const arrayBuffer = await res.arrayBuffer()
+  const response = await fetch('https://www.quicpay.jp/campaign/')
+  if (!response.ok) throw new Error(`HTTP error: ${response.status}`)
+  const arrayBuffer = await response.arrayBuffer()
   const buffer = Buffer.from(arrayBuffer)
   const $ = cheerio.load(buffer)
   const campaignItems = $('div#comCampaignList .campaign-item')
@@ -64,7 +64,7 @@ export async function getCampaigns(): Promise<QuicpayCampaign[]> {
     })
   }
 
-  if (!checkAllNotUndefined(results)) {
+  if (!isAllDefined(results)) {
     throw new Error('some results are undefined')
   }
 


### PR DESCRIPTION
## 概要
Renovate PR #2282 (`@book000/eslint-config` 1.15.4 -> 1.15.44) が CI 失敗しているのは、bump 自体ではなく、新しく強化された `eslint-plugin-unicorn` ルールによって既存コードの命名規則違反が検出されたためです。本 PR はその lint エラーを機械的に解消します。

## 対応内容
- `unicorn/name-replacements`: `Configuration` -> `Config` (src/config.ts, src/discord.ts)、`res` -> `response` (src/discord.ts, src/quicpay-campaigns.ts)
- `unicorn/consistent-boolean-name`: `checkAllNotUndefined` -> `isAllDefined` (src/quicpay-campaigns.ts)
- `unicorn/prefer-await`: src/main.ts の `.catch()` チェーンを `await`/`try-catch` に変更
- `generate-schema` スクリプトのシンボル名、CLAUDE.md の記述を `Config` に追従 (スキーマファイル名 `schema/Configuration.json` は公開アーティファクトのため変更なし。生成物は byte-identical であることを確認済み)

## 検証
- ローカルで `pnpm run lint` (prettier+eslint+tsc) / `pnpm test` が現行の `@book000/eslint-config@1.15.4` / bump 対象の `1.15.44` 双方で clean であることを確認済み (1.15.44 は動作確認のため一時的に導入、コミットには含めていません)。
- 本 PR は master から作成しており、Renovate PR #2282 のブランチには手を加えていません。

Renovate PR: #2282