### PR TITLE
chore: worktree 用に data/config.json と data/notified.json を追加

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,2 @@
+data/config.json
+data/notified.json


### PR DESCRIPTION
## 概要

`git worktree` 作成時に含めるべきファイルを指定する `.worktreeinclude` を新規追加します。

## 追加したパターン

- `data/config.json`
- `data/notified.json`

## 根拠

- `src/config.ts` の `PATH.config` は `data/config.json` を既定値とし (`CONFIG_PATH` 環境変数で変更可)、`loadConfig()` がこのパスを `fs.readFileSync` + `JSON.parse` で読み込む。`PATH.notified` も同様に `data/notified.json` を既定値とする (`NOTIFIED_PATH` で変更可)。
- `compose.yml` はホストの `./data` をコンテナの `/data` にバインドマウントしており、設定・状態ディレクトリが Git 管理外に存在する構成になっている。
- README.md の Configuration セクションに記載の通り、`data/config.json` は利用者が手動作成する必要があり、リポジトリ内にテンプレートは存在しない (Discord Webhook URL やトークンなどの秘匿情報を含むため)。
- `git ls-files` で `data/` 配下のファイルが一切追跡されていないことを確認済み。
- `data/config.json` を含めないと新規 worktree 作成時に設定ファイルが存在せず、アプリが `Config file not found` 相当のエラーで起動できない。`data/notified.json` は通知済み状態を worktree 間で引き継ぐために追加。

## 関連 Issue

https://github.com/book000/book000/issues/132
